### PR TITLE
Implemented reqManagedAccts, tested for both FA & Individual account

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -30,8 +30,10 @@ export(twsConnect,
 
        twsPortfolioValue,
 
-       # FA accounts only - untested as there is a missing EWrapper method here
+       # Both Family and individual tested, implemented the EWrapper to make it work
        reqManagedAccts,
+
+       # FA accounts only - untested as there is a missing EWrapper method here
        requestFA,
        replaceFA,
 
@@ -74,7 +76,7 @@ export(twsConnect,
        calculateImpliedVolatility,
       .calculateOptionPrice,
        calculateOptionPrice,
-     
+
 
        reqMktDepth,
        cancelMktDepth,
@@ -95,7 +97,7 @@ export(twsConnect,
 
        reqNewsBulletins,
        cancelNewsBulletins,
-    
+
        twsCALLBACK,
        twsDEBUG,
        processMsg,

--- a/R/reqManagedAccts.R
+++ b/R/reqManagedAccts.R
@@ -1,12 +1,37 @@
+.reqManagedAccts <-
+    function(conn) {
+        if(!isConnected(conn))
+            stop('peer has gone away. check your IB connection',call.=FALSE)
+        if(!is.twsConnection(conn))
+            stop('requires twsConnection object')
+
+        con <- conn[[1]]
+
+        VERSION <- "1"
+        outgoing <- c(.twsOutgoingMSG$REQ_MANAGED_ACCTS, VERSION)
+
+        writeBin(outgoing, con)
+}
+
 reqManagedAccts <- function(twsconn) {
-  if( !is.twsConnection(twsconn))
-    stop('invalid twsConnection')
+  .reqManagedAccts(twsconn)
+  con <- twsconn[[1]]
+  e_managed_acc <- eWrapper()
+  while (isConnected(twsconn)) {
+      socketSelect(list(con), FALSE, NULL)
+      curMsg <- readBin(con, character(), 1)
+      accounts_raw <- processMsg(curMsg,
+                                con,
+                                eWrapper=e_managed_acc,
+                                twsconn=twsconn,
+                                timestamp=NULL, file="")
+      if(curMsg == .twsIncomingMSG$MANAGED_ACCTS)
+          break
+  }
+  # Clean up ending "," when multiple accounts are reported.
+  accounts <- if(endsWith(accounts_raw[3], ",")) substring(accounts_raw[3],1, nchar(accounts_raw[3]) - 1) else accounts_raw[3]
 
-  VERSION <- "1"
-
-  writeBin(c(.twsOutgoingMSG$REQ_MANAGED_ACCTS,
-             VERSION), 
-           twsconn[[1]])
+  return(accounts)
 }
 
 requestFA <- function(twsconn, faDataType) {
@@ -16,8 +41,8 @@ requestFA <- function(twsconn, faDataType) {
   VERSION <- "1"
 
   writeBin(c(.twsOutgoingMSG$REQ_FA,
-             VERSION, 
-             as.character(faDataType)), 
+             VERSION,
+             as.character(faDataType)),
            twsconn[[1]])
 }
 
@@ -31,5 +56,5 @@ replaceFA <- function(twsconn, faDataType, xml) {
               VERSION,
               as.character(faDataType),
               as.character(xml)),
-           twsconn[[1]]) 
+           twsconn[[1]])
 }

--- a/man/reqManagedAccts.Rd
+++ b/man/reqManagedAccts.Rd
@@ -1,0 +1,24 @@
+\name{reqManagedAccts}
+\alias{reqManagedAccts}
+\title{ Managed Accounts }
+\description{
+A single username can handle more than one account. As mentioned in the Connectivity section, the TWS will automatically send a list of managed accounts once the connection is established. The list can also be fetched via the IBApi.EClient.reqManagedAccts method. For an individual account, this call works as well and returns a single account.
+}
+\usage{
+reqManagedAccts(twsconn)
+}
+\arguments{
+  \item{twsconn}{ a valid tws connection object }
+}
+\value{
+Individual account: a string containing a single account number. For a FamilyAccount  it returns a string with a ',' separated list of available accounts.
+}
+\references{ Interactive Brokers \url{https://www.interactivebrokers.com}}
+\author{ Jeffrey A. Ryan }
+\examples{
+\dontrun{
+tws <- twsConnect()
+reqManagedAccts(tws)
+}
+}
+\keyword{ utilities }


### PR DESCRIPTION
Implemented the EWrapper function reqManagedAccts. It works for both individual accounts as Family Accounts (both tested). Also added a short manual page. Hope this helps. This call is particular helpful to find out what accounts are available when using a family account of FA account. (FA account not tested but presume it's equal to the Family & Friends account)
